### PR TITLE
Refactor control node names and publish joints

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then run the converter and controller:
 
 ```bash
 ros2 run unity_transform vive_to_xarm
-ros2 run xarm_control ee_pose_controller --ros-args -p robot_ip:=<ip>
+ros2 run xarm_control xarm_control --ros-args -p robot_ip:=<ip>
 ```
 
 Finally, launch the Unity scene and move the controller to drive

--- a/src/xarm_control/README.md
+++ b/src/xarm_control/README.md
@@ -4,7 +4,7 @@ ROS 2 package containing nodes for commanding the xArm6.
 
 ## Nodes
 
-### `ee_pose_controller`
+### `xarm_control`
 Real-time Cartesian controller for the xArm6.
 
 - **Subscriptions**
@@ -12,17 +12,18 @@ Real-time Cartesian controller for the xArm6.
   - `/xarm6/gripper_cmd` (`control_msgs/GripperCommand`): gripper position and effort.
 - **Publications**
   - `/xarm6/ee_pose_current` (`geometry_msgs/Twist`): pose feedback published at 50 Hz.
+  - `/xarm6/joints_values` (`std_msgs/Float64MultiArray`): current joint angles published at 50 Hz.
 - **Parameters**
   - `robot_ip` – IP address of the arm (default `192.168.1.217`).
 
 Run the controller with:
 
 ```bash
-ros2 run xarm_control ee_pose_controller --ros-args -p robot_ip:=<robot-ip>
+ros2 run xarm_control xarm_control --ros-args -p robot_ip:=<robot-ip>
 ```
 
-### `ee_demo_sinus_publisher`
-Publishes a simple sinusoidal trajectory on `/xarm6/ee_pose_cmd` for testing.
+### `demo_circle_publisher`
+Publishes a simple circular trajectory on `/xarm6/ee_pose_cmd` for testing.
 
 ### `teleop_keyboard`
 Keyboard interface that sends Cartesian pose commands and gripper commands. See the source for key bindings.

--- a/src/xarm_control/setup.py
+++ b/src/xarm_control/setup.py
@@ -19,8 +19,8 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "ee_pose_controller = xarm_control.ee_pose_controller:main",
-            "ee_demo_sinus_publisher = xarm_control.ee_demo_sinus_publisher:main",
+            "xarm_control = xarm_control.xarm_control:main",
+            "demo_circle_publisher = xarm_control.demo_circle_publisher:main",
             "teleop_keyboard = xarm_control.teleop_keyboard:main",
         ],
     },

--- a/src/xarm_control/xarm_control/demo_circle_publisher.py
+++ b/src/xarm_control/xarm_control/demo_circle_publisher.py
@@ -12,11 +12,11 @@ from geometry_msgs.msg import Twist
 from rclpy.node import Node
 
 
-class EESinusPublisher(Node):
-    """ROS2 node that publishes a sinusoidal trajectory for the end-effector."""
+class DemoCirclePublisher(Node):
+    """ROS2 node that publishes a circular trajectory for the end-effector."""
 
     def __init__(self) -> None:
-        super().__init__("ee_demo_sinus_publisher")
+        super().__init__("demo_circle_publisher")
 
         # Create publisher for end-effector pose commands
         self.publisher = self.create_publisher(Twist, "/xarm6/ee_pose_cmd", 10)
@@ -59,7 +59,7 @@ class EESinusPublisher(Node):
 def main(args=None) -> None:
     """Initialize ROS2 node and spin until shutdown."""
     rclpy.init(args=args)
-    node = EESinusPublisher()
+    node = DemoCirclePublisher()
     try:
         rclpy.spin(node)
     finally:


### PR DESCRIPTION
## Summary
- rename `ee_pose_controller` to `xarm_control`
- rename `ee_demo_sinus_publisher` to `demo_circle_publisher`
- publish joint angles on `/xarm6/joints_values`
- update package entry points and README docs