### PR TITLE
Refactor unity_transform modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ First, start the WebSocket bridge (see `unity/README.md`).\
 Then run the converter and controller:
 
 ```bash
-ros2 run unity_transform vive_to_xarm
+ros2 run unity_transform unity_to_xarm
 ros2 run xarm_control xarm_control --ros-args -p robot_ip:=<ip>
 ```
 

--- a/src/unity_transform/README.md
+++ b/src/unity_transform/README.md
@@ -1,12 +1,12 @@
 # unity_transform
 
-ROS 2 package that converts Vive controller data from Unity into xArm6 commands.
+ROS 2 package that converts unity controller data from Unity into xArm6 commands.
 
 ## Node
 
-### `vive_to_xarm`
+### `unity_to_xarm`
 
-Unified node that converts Vive controller poses into xArm6 Cartesian commands.
+Unified node that converts unity controller poses into xArm6 Cartesian commands.
 It supports two modes:
 
 - **Relative** (`--is_relative True`, default) – controller motion is applied
@@ -28,11 +28,11 @@ The relative mode implementation is inspired by the approach presented in
   - `offset_x`, `offset_y`, `offset_z` – translation offsets in millimetres.
   - `offset_roll`, `offset_pitch`, `offset_yaw` – orientation offsets in degrees.
 
-These offsets were tuned for one Vive room configuration and may need
+These offsets were tuned for one unity room configuration and may need
 adjustment in a different environment.
 
 Run the node with:
 
 ```bash
-ros2 run unity_transform vive_to_xarm --is_relative True
+ros2 run unity_transform unity_to_xarm --is_relative True
 ```

--- a/src/unity_transform/setup.py
+++ b/src/unity_transform/setup.py
@@ -19,7 +19,7 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "vive_to_xarm = unity_transform.vive_to_xarm:main",
+            "unity_to_xarm = unity_transform.unity_to_xarm:main",
         ],
     },
 )

--- a/src/unity_transform/unity_transform/__init__.py
+++ b/src/unity_transform/unity_transform/__init__.py
@@ -1,12 +1,12 @@
 """Utility modules for converting Unity poses to xArm commands."""
 
-from .vive_to_xarm import ViveToXarm
+from .unity_to_xarm import UnityToXarm
 from .absolute_motion import AbsoluteMotion
 from .relative_motion import RelativeMotion
 from .utils import convert_pose, sawtooth, twist_to_vector, vector_to_twist
 
 __all__ = [
-    "ViveToXarm",
+    "UnityToXarm",
     "AbsoluteMotion",
     "RelativeMotion",
     "convert_pose",

--- a/src/unity_transform/unity_transform/absolute_motion.py
+++ b/src/unity_transform/unity_transform/absolute_motion.py
@@ -1,17 +1,22 @@
-from .utils import convert_pose
+from rclpy.node import Node
+from geometry_msgs.msg import Twist
+
+from .utils import convert_pose, vector_to_twist
 
 
 class AbsoluteMotion:
-    """Compute absolute pose commands from Vive controller data."""
-    def __init__(self, node):
+    """Compute absolute pose commands from unity controller data."""
+
+    def __init__(self, node: Node) -> None:
         self.node = node
 
-    def handle_pose(self, msg):
-        new_msg = convert_pose(
+    def handle_pose(self, msg: Twist) -> None:
+        vector = convert_pose(
             self.node.R_matrix,
             msg,
             offsets=self.node.offsets,
-        ) # now that convert_pose has been modified, we sould reconvert the array to a msg.
+        )
+        new_msg = vector_to_twist(vector)
         self.node.pub.publish(new_msg)
         self.node.get_logger().info(
             f"Published xArm6 pose: linear=({new_msg.linear.x:.1f}, {new_msg.linear.y:.1f}, {new_msg.linear.z:.1f}), "

--- a/src/xarm_control/xarm_control/teleop_keyboard.py
+++ b/src/xarm_control/xarm_control/teleop_keyboard.py
@@ -44,7 +44,7 @@ GRIPPER_MAX = 850.0
 class TeleopKeyboard(Node):
     """ROS2 node for keyboard teleoperation of xArm6 in Cartesian space."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("teleop_keyboard")
 
         # Publishers for end-effector and gripper
@@ -89,20 +89,23 @@ class TeleopKeyboard(Node):
         fcntl.fcntl(self.fd, fcntl.F_SETFL, self.old_flags | os.O_NONBLOCK)
 
     @property
-    def gripper(self):
+    def gripper(self) -> float:
+        """Current gripper opening."""
+
         return self._gripper
 
     @gripper.setter
-    def gripper(self, value):
-        # Clamp gripper position within its limits
+    def gripper(self, value: float) -> None:
+        """Set gripper opening within allowed limits."""
+
         self._gripper = np.clip(value, GRIPPER_MIN, GRIPPER_MAX)
 
-    def _current_pose_cb(self, msg: Twist):
+    def _current_pose_cb(self, msg: Twist) -> None:
         """Callback for receiving current end-effector pose from the robot."""
         self.curr_linear = [msg.linear.x, msg.linear.y, msg.linear.z]
         self.curr_angular = [msg.angular.x, msg.angular.y, msg.angular.z]
 
-    def keyboard_loop(self):
+    def keyboard_loop(self) -> None:
         """Main loop: read keyboard inputs and publish corresponding commands."""
         try:
             while rclpy.ok():
@@ -157,7 +160,9 @@ class TeleopKeyboard(Node):
             fcntl.fcntl(self.fd, fcntl.F_SETFL, self.old_flags)
 
 
-def main(args=None):
+def main(args: list[str] | None = None) -> None:
+    """Entry point for the keyboard teleoperation node."""
+
     rclpy.init(args=args)
     node = TeleopKeyboard()
     try:

--- a/src/xarm_control/xarm_control/xarm_control.py
+++ b/src/xarm_control/xarm_control/xarm_control.py
@@ -20,7 +20,7 @@ from xarm.wrapper import XArmAPI
 class XArmCartesianController(Node):
     """ROS2 node for controlling xArm in Cartesian space."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("xarm_control")
 
         # Declare and read robot IP parameter
@@ -101,8 +101,10 @@ class XArmCartesianController(Node):
         ]
         self.get_logger().info(f"End-effector command received: {self.ee_cmd}")
 
-    def _gripper_cb(self, msg):
-        pos_mm = np.clip(msg.position, -10.0, 850.0)  # -10 to 85 mm for xArm gripper
+    def _gripper_cb(self, msg: GripperCommand) -> None:
+        """Handle gripper command messages."""
+
+        pos_mm = np.clip(msg.position, -10.0, 850.0)
         speed = np.clip(msg.max_effort, 350.0, 5000.0)
 
         self.arm.set_gripper_position(pos_mm, speed=speed, wait=False)


### PR DESCRIPTION
## Summary
- refactor convert_pose helper to return arrays
- store origin poses as vectors in relative motion handler
- rename ViveToXarm to UnityToXarm and update entrypoint
- add type hints and docstrings across modules
- rename callback arguments and update gripper handling
- fix variable naming in relative motion and update documentation